### PR TITLE
Add SteamLibrary path check for Nadeo.ini

### DIFF
--- a/operators/OT_Settings.py
+++ b/operators/OT_Settings.py
@@ -232,6 +232,7 @@ def find_nadeo_ini_trackmania2020():
         paths.append(fr"{char}:\Ubisoft Game Launcher\games\Trackmania\Nadeo.ini")
         paths.append(fr"{char}:\Epic Games\TrackmaniaNext\Nadeo.ini")
         paths.append(fr"{char}:\games\uplay\Trackmania\Nadeo.ini")
+        paths.append(fr"{char}:\SteamLibrary\steamapps\common\Trackmania\Nadeo.ini")
 
     debug("Try to find Nadeo.ini for trackmania2020 in most used installation paths:")
 

--- a/properties/Functions.py
+++ b/properties/Functions.py
@@ -9,6 +9,8 @@ from ..utils.ItemsIcon import generate_world_node
 from ..utils.Functions import *
 from ..utils.Constants import *
 
+from ..operators.OT_Settings import autoFindNadeoIni
+
 class EnumProps():
     """this needs to be returned by bpy.props.EnumProperty"""
     def __init__(self):
@@ -144,6 +146,12 @@ def gameTypeGotUpdated(self=None,context=None)->None:
 
     tm_props     = get_global_props()
     colIsStadium = tm_props.LI_materialCollection.lower() == "stadium"
+
+    if is_game_maniaplanet() and tm_props.ST_nadeoIniFile_MP == "":
+        autoFindNadeoIni()
+
+    if is_game_trackmania2020() and tm_props.ST_nadeoIniFile_TM == "":
+        autoFindNadeoIni()
 
     if is_game_trackmania2020() and not colIsStadium:
         tm_props.LI_materialCollection = "Stadium"


### PR DESCRIPTION
These are entirely just tiny tweaks to remove the friction when using the addon for the first time. It was constantly annoying me that I had to select my ini file manually every time I opened a fresh Blender save, since my Trackmania 2020 install is in my Steam library on a separate drive from my C: drive.

- Added a check for SteamLibrary folders rooted on other drives when searching for Nadeo.ini
- Added a call to autoFindNadeoIni when gameTypeGotUpdated and the ini path is empty
    - This is useful for when you're opening a fresh blend file, and you switch between games. It will automatically find the ini file when you make that switch, without you manually having to press the autoFindNadeoIni button